### PR TITLE
Update nginx.conf.template

### DIFF
--- a/server/nginx.conf.template
+++ b/server/nginx.conf.template
@@ -39,7 +39,6 @@ http {
 
 	server {
 		listen 80;
-		server_name ${SERVER_NAME}; # Set server name to environment variable
 
 		# root directory
 		root /usr/share/nginx/html;


### PR DESCRIPTION
server_name is not necessary and can lead to misinterpretation, in case the host value should be read from the header X-Forwarded